### PR TITLE
Updated spelling on output

### DIFF
--- a/Veeam/PRTG-VeeamBRStats.ps1
+++ b/Veeam/PRTG-VeeamBRStats.ps1
@@ -366,7 +366,7 @@ if ($includeCopy) {
                 "</result>"
     $Count = $failsSessionsBkC.Count
     Write-Output "<result>"
-                "  <channel>Failed-BackupCopys</channel>"
+                "  <channel>Fails-BackupCopys</channel>"
                 "  <value>$Count</value>"
                 "  <showChart>1</showChart>"
                 "  <showTable>1</showTable>"

--- a/Veeam/PRTG-VeeamBRStats.ps1
+++ b/Veeam/PRTG-VeeamBRStats.ps1
@@ -366,7 +366,7 @@ if ($includeCopy) {
                 "</result>"
     $Count = $failsSessionsBkC.Count
     Write-Output "<result>"
-                "  <channel>Failes-BackupCopys</channel>"
+                "  <channel>Failed-BackupCopys</channel>"
                 "  <value>$Count</value>"
                 "  <showChart>1</showChart>"
                 "  <showTable>1</showTable>"
@@ -432,7 +432,7 @@ if ($includeRepl) {
                 "</result>"
     $Count = $failsSessionsRepl.Count
     Write-Output "<result>"
-                "  <channel>Failes-Replications</channel>"
+                "  <channel>Failed-Replications</channel>"
                 "  <value>$Count</value>"
                 "  <showChart>1</showChart>"
                 "  <showTable>1</showTable>"
@@ -489,7 +489,7 @@ if ($includeEP) {
                 "</result>"
     $Count = $failsSessionsEP.Count
     Write-Output "<result>"
-                "  <channel>Failes-Endpoints</channel>"
+                "  <channel>Failed-Endpoints</channel>"
                 "  <value>$Count</value>"
                 "  <showChart>1</showChart>"
                 "  <showTable>1</showTable>"


### PR DESCRIPTION
I thought that the spelling might be wrong on the PRTG output sections. As an example:

```
    Write-Output "<result>"
                "  <channel>Failes-Backups</channel>"
                "  <value>$Count</value>"
                "  <showChart>1</showChart>"
                "  <showTable>1</showTable>"
                "  <LimitMaxError>0</LimitMaxError>"
                "  <LimitMode>1</LimitMode>"
                "</result>"
```

Changed to:

```
    Write-Output "<result>"
                "  <channel>Failed-Backups</channel>"
                "  <value>$Count</value>"
                "  <showChart>1</showChart>"
                "  <showTable>1</showTable>"
                "  <LimitMaxError>0</LimitMaxError>"
                "  <LimitMode>1</LimitMode>"
                "</result>"
```