### PR TITLE
Fixed Veeam Snapin PS Version

### DIFF
--- a/Veeam/PRTG-VeeamBRStats.ps1
+++ b/Veeam/PRTG-VeeamBRStats.ps1
@@ -159,7 +159,7 @@ if ($Module = Get-Module -ListAvailable -Name Veeam.Backup.PowerShell) {
     else {
         Write-Host "No Veeam Modules found, Fallback to SnapIn."
         try {
-            [int]$VbrVersion = (Get-PSSnapin VeeamPSSnapin).Version.ToString()
+            [int]$VbrVersion = (Get-PSSnapin VeeamPSSnapin).PSVersion.ToString()
             }
             catch {
                 throw "Failed to get Version from Module or SnapIn"


### PR DESCRIPTION
It seems that the script don't work with the old Veeam versions, because of the snapin version property is different.